### PR TITLE
Add support for reporting end points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+target/
+**/target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.0 (June 22, 2015)
+
+* Added support for getting report data. See [developer docs](http://developer.helpscout.net/reports/conversations/conversations/) for more information.
+
 #### 1.3.13 (April 25, 2014)
 
 * Added support for updating the body text of a thread. See [developer docs](http://developer.helpscout.net/) for more information.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Help Scout Java Wrapper
 =======================
 Java Wrapper for the Help Scout API. More information on our developer site: [http://developer.helpscout.net](http://developer.helpscout.net).
 
-Version 1.3.13 Released
+Version 1.4.0 Released
 ---------------------
 Please see the [Changelog](https://github.com/helpscout/helpscout-api-java/blob/master/CHANGELOG.md) for details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>net.helpscout</groupId>
   <artifactId>helpscout-api</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.13</version>
+  <version>1.4.0</version>
   <name>helpscout-api</name>
   <url>http://maven.apache.org</url>
 
@@ -28,6 +28,12 @@
             <version>1.6.6</version>
             <scope>compile</scope>
         </dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.16.4</version>
+			<scope>provided</scope>
+		</dependency>
   </dependencies>
   <repositories>
 		<repository>

--- a/src/main/java/net/helpscout/api/Parser.java
+++ b/src/main/java/net/helpscout/api/Parser.java
@@ -1,17 +1,18 @@
 package net.helpscout.api;
 
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
+import java.util.Date;
+
 import net.helpscout.api.adapters.*;
 import net.helpscout.api.cbo.*;
 import net.helpscout.api.model.Conversation;
 import net.helpscout.api.model.Customer;
 import net.helpscout.api.model.ref.PersonRef;
+import net.helpscout.api.model.report.common.DateAndCount;
 import net.helpscout.api.model.thread.LineItem;
 
-import java.util.Date;
-
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 public final class Parser {
 	private final GsonBuilder builder;
@@ -30,6 +31,8 @@ public final class Parser {
         builder.registerTypeAdapter(WorkflowType.class, new WorkflowTypeAdapter());
 		builder.registerTypeAdapter(PersonRef.class, new PersonRefAdapter(builder));
 		builder.registerTypeAdapter(LineItem.class, new ThreadsAdapater(builder));
+		
+		builder.registerTypeAdapter(DateAndCount.class, new DateAndCountDeserializer(builder));
 	}
 
 	public synchronized static Parser getInstance() {
@@ -48,11 +51,16 @@ public final class Parser {
 		JsonElement obj  = (new JsonParser()).parse(json);
 		return (Customer)getObject(obj, Customer.class);
 	}
+	
+	public <T> T getObject(String json, Class<T> clazzType) {
+	    JsonElement obj  = new JsonParser().parse(json);
+	    return getObject(obj, clazzType);
+	}
 
-	public Object getObject(JsonElement item, Class<?> clazzType) {
+	public <T> T getObject(JsonElement item, Class<T> clazzType) {
 		JsonThreadLocal.set(item);
 
-		Object clazz = builder.create().fromJson(item, clazzType);
+		T clazz = builder.create().fromJson(item, clazzType);
 
 		JsonThreadLocal.unset();
 

--- a/src/main/java/net/helpscout/api/adapters/DateAndCountDeserializer.java
+++ b/src/main/java/net/helpscout/api/adapters/DateAndCountDeserializer.java
@@ -1,0 +1,53 @@
+package net.helpscout.api.adapters;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+import lombok.RequiredArgsConstructor;
+import net.helpscout.api.model.report.common.DateAndCount;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+@RequiredArgsConstructor
+public class DateAndCountDeserializer implements JsonDeserializer<DateAndCount> {
+    
+    private final GsonBuilder gson;
+    
+    public DateAndCount deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        
+        DateAndCount stat = new DateAndCount();
+        stat.setDate(extractDate(json.getAsJsonObject()));
+        stat.setCount(extractCount(json.getAsJsonObject()));
+        
+        return stat;
+    }
+    
+    protected int extractCount(JsonObject json) {
+        // The API refers to the count by various names depending on context.
+        if(json.has("count"))     return json.get("count").getAsInt();
+        if(json.has("customers")) return json.get("customers").getAsInt();
+        if(json.has("replies"))   return json.get("replies").getAsInt();
+        if(json.has("resolved"))  return json.get("resolved").getAsInt();
+        
+        throw new JsonParseException("Unable to parse the count for " + json);
+    }
+    
+    protected Date extractDate(JsonObject json) {
+        // The API refers to the date by various names depending on context.
+        if(json.has("start")) return getDateByName(json, "start");
+        if(json.has("date"))  return getDateByName(json, "date");
+        
+        throw new JsonParseException("Unable to parse the date for " + json);
+    }
+    
+    protected Date getDateByName(JsonObject json, String name) {
+        JsonElement date = json.get(name);
+        return gson.create().fromJson(date, Date.class);
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/common/DateAndCount.java
+++ b/src/main/java/net/helpscout/api/model/report/common/DateAndCount.java
@@ -1,0 +1,15 @@
+package net.helpscout.api.model.report.common;
+
+import java.util.Date;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DateAndCount {
+
+    Date date;
+    Integer count;
+}

--- a/src/main/java/net/helpscout/api/model/report/common/DateAndElapsedTime.java
+++ b/src/main/java/net/helpscout/api/model/report/common/DateAndElapsedTime.java
@@ -1,0 +1,15 @@
+package net.helpscout.api.model.report.common;
+
+import java.util.Date;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DateAndElapsedTime {
+
+    Date date;
+    Double time;
+}

--- a/src/main/java/net/helpscout/api/model/report/common/DatesAndCounts.java
+++ b/src/main/java/net/helpscout/api/model/report/common/DatesAndCounts.java
@@ -1,0 +1,15 @@
+package net.helpscout.api.model.report.common;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DatesAndCounts {
+
+    List<DateAndCount> current;
+    List<DateAndCount> previous;
+}

--- a/src/main/java/net/helpscout/api/model/report/common/DatesAndElapsedTimes.java
+++ b/src/main/java/net/helpscout/api/model/report/common/DatesAndElapsedTimes.java
@@ -1,0 +1,15 @@
+package net.helpscout.api.model.report.common;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DatesAndElapsedTimes {
+
+    List<DateAndElapsedTime> current;
+    List<DateAndElapsedTime> previous;
+}

--- a/src/main/java/net/helpscout/api/model/report/common/Rating.java
+++ b/src/main/java/net/helpscout/api/model/report/common/Rating.java
@@ -1,0 +1,26 @@
+package net.helpscout.api.model.report.common;
+
+import java.util.Date;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.cbo.ConversationType;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Rating {
+
+    Integer number;
+    Integer id;
+    ConversationType type;
+    Integer threadid;
+    Date threadCreatedAt;
+    Integer ratingId;
+    Integer ratingCustomerId;
+    String ratingComments;
+    Date ratingCreatedAt;
+    String ratingCustomerName;
+    Integer ratingUserId;
+    String ratingUserName;
+}

--- a/src/main/java/net/helpscout/api/model/report/common/Tag.java
+++ b/src/main/java/net/helpscout/api/model/report/common/Tag.java
@@ -1,0 +1,14 @@
+package net.helpscout.api.model.report.common;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Tag {
+
+    String name;
+    Long id;
+    String color;
+}

--- a/src/main/java/net/helpscout/api/model/report/conversations/Conversation.java
+++ b/src/main/java/net/helpscout/api/model/report/conversations/Conversation.java
@@ -1,0 +1,33 @@
+package net.helpscout.api.model.report.conversations;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.cbo.ConversationType;
+import net.helpscout.api.cbo.Status;
+import net.helpscout.api.model.report.common.Tag;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Conversation {
+
+    Integer id;
+    Integer number;
+    ConversationType type;
+    Integer mailboxid;
+    Boolean attachments;
+    String subject;
+    Status status;
+    Integer threadCount;
+    String preview;
+    String customerName;
+    String customerEmail;
+    List<Integer> customerIds;
+    Date modifiedAt;
+    Integer assignedid;
+    List<Tag> tags;
+    String assignedName;
+}

--- a/src/main/java/net/helpscout/api/model/report/conversations/ConversationsReport.java
+++ b/src/main/java/net/helpscout/api/model/report/conversations/ConversationsReport.java
@@ -1,0 +1,135 @@
+package net.helpscout.api.model.report.conversations;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.model.report.common.Tag;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConversationsReport {
+
+    List<Tag> filterTags;
+    DayStats busiestDay;
+    Integer busyTimeStart;
+    Integer busyTimeEnd;
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    MultipleTimeRangeStats delta;
+    TagStats tags;
+    CustomerStats customers;
+    SavedReplyStats replies;
+    WorkflowStats workflows;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Date startDate;
+        Date endDate;
+        Integer totalConversations;
+        Integer conversationsCreated;
+        Integer newConversations;
+        Integer customers;
+        Integer conversationsPerDay;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class MultipleTimeRangeStats {
+
+        Double newConversations;
+        Double totalConversations;
+        Double customers;
+        Double conversationsCreated;
+        Double conversationsPerDay;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TagStats {
+
+        Integer count;
+        List<TagStat> top;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TagStat {
+
+        String name;
+        Integer id;
+        Integer count;
+        Integer previousCount;
+        Double percent;
+        Double previousPercent;
+        Double deltaPercent;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class CustomerStats {
+
+        Integer count;
+        List<CustomerStat> top;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class CustomerStat {
+
+        String name;
+        Integer id;
+        Integer count;
+        Double previousCount;
+        Double percent;
+        Double previousPercent;
+        Double deltaPercent;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class SavedReplyStats {
+
+        Integer count;
+        List<SavedReplyStat> replies;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class SavedReplyStat {
+
+        String name;
+        Integer id;
+        Integer mailboxId;
+        Integer count;
+        Integer previousCount;
+        Double percent;
+        Double previousPercent;
+        Double deltaPercent;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class WorkflowStats {
+
+        Integer count;
+        List<WorkflowStat> top;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class WorkflowStat {
+
+        String name;
+        Integer id;
+        Integer count;
+        Integer previousCount;
+        Double percent;
+        Double previousPercent;
+        Double deltaPercent;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/conversations/DayStats.java
+++ b/src/main/java/net/helpscout/api/model/report/conversations/DayStats.java
@@ -1,0 +1,14 @@
+package net.helpscout.api.model.report.conversations;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DayStats {
+
+    Integer day;
+    Integer hour;
+    Integer count;
+}

--- a/src/main/java/net/helpscout/api/model/report/docs/DocsReport.java
+++ b/src/main/java/net/helpscout/api/model/report/docs/DocsReport.java
@@ -1,0 +1,63 @@
+package net.helpscout.api.model.report.docs;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DocsReport {
+
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    List<SearchStats> popularSearches;
+    List<SearchStats> failedSearches;
+    List<ArticleStats> topArticles;
+    List<ArticleStats> topCategories;
+    DeltaStats deltas;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Integer visitors;
+        Double browseAction;
+        Double sentAnEmailResult;
+        Double foundAnAnswerResult;
+        Double searchAction;
+        Double failedResult;
+        Double docsViewedPerVisit;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class SearchStats {
+
+        Integer count;
+        String id;
+        Integer results;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class ArticleStats {
+
+        Integer count;
+        String id;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class DeltaStats {
+
+        Double failedResult;
+        Double docsViewedPerVisit;
+        Double foundAnAnswerResult;
+        Double visitors;
+        Double browseAction;
+        Double searchAction;
+        Double sentAnEmailResult;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/happiness/HappinessReport.java
+++ b/src/main/java/net/helpscout/api/model/report/happiness/HappinessReport.java
@@ -1,0 +1,48 @@
+package net.helpscout.api.model.report.happiness;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.model.report.common.Tag;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class HappinessReport {
+
+    List<Tag> filterTags;
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    MultipleTimeRangeStats deltas;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Double okay;
+        Integer notGoodCount;
+        Integer totalCustomers;
+        Double happinessScore;
+        Integer totalCustomersWithRatings;
+        Integer ratingsCount;
+        Double ratingsPercent;
+        Double notGood;
+        Double great;
+        Integer greatCount;
+        Integer okayCount;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class MultipleTimeRangeStats {
+
+        Double okay;
+        Double notGoodCount;
+        Double happinessScore;
+        Double notGood;
+        Double great;
+        Double greatCount;
+        Double okayCount;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/productivity/ProductivityReport.java
+++ b/src/main/java/net/helpscout/api/model/report/productivity/ProductivityReport.java
@@ -1,0 +1,98 @@
+package net.helpscout.api.model.report.productivity;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.model.report.common.Tag;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ProductivityReport {
+
+    List<Tag> filterTags;
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    MultipleTimeRangeStats deltas;
+    ProductivityStats responseTime;
+    ProductivityStats handleTime;
+    ProductivityStats firstResponseTime;
+    RepliesToResolveStats repliesToResolve;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Date startDate;
+        Date endDate;
+        Integer totalConversations;
+        Double resolutionTime;
+        Double repliesToResolve;
+        Double responseTime;
+        Double firstResponseTime;
+        Integer resolved;
+        Integer resolvedOnFirstReply;
+        Integer closed;
+        Integer repliesSent;
+        Integer handleTime;
+        Double percentResolvedOnFirstReply;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class MultipleTimeRangeStats {
+
+        Double firstResponseTime;
+        Double handleTime;
+        Double repliesSent;
+        Double responseTime;
+        Double totalConversations;
+        Double repliesToResolve;
+        Double closed;
+        Double resolvedOnFirstReply;
+        Double resolutionTime;
+        Double resolved;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class ProductivityStats {
+
+        Integer count;
+        Integer previousCount;
+        List<DrillDownStats> ranges;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class RepliesToResolveStats {
+
+        Integer count;
+        Integer previousCount;
+        List<RepliesToResolveDrillDownStats> ranges;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class DrillDownStats {
+
+        Integer id;
+        Integer count;
+        Integer previousCount;
+        Double percent;
+        Double previousPercent;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = true)
+    @ToString(callSuper = true)
+    public class RepliesToResolveDrillDownStats extends DrillDownStats {
+
+        Double resolutionTime;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/team/TeamReport.java
+++ b/src/main/java/net/helpscout/api/model/report/team/TeamReport.java
@@ -1,0 +1,64 @@
+package net.helpscout.api.model.report.team;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.model.report.common.Tag;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TeamReport {
+
+    List<Tag> filterTags;
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    MultipleTimeRangeStats deltas;
+    List<UserStats> users;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Date startDate;
+        Date endDate;
+        Integer customersHelped;
+        Integer closed;
+        Integer totalReplies;
+        Integer totalUsers;
+        Integer totalDays;
+        Double repliesPerDayPerUser;
+        Double repliesPerDay;
+        Double resolvedPerDay;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class MultipleTimeRangeStats {
+
+        Double repliesPerDay;
+        Double totalUsers;
+        Double totalReplies;
+        Double customersHelped;
+        Double repliesPerDayPerUser;
+        Double closed;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class UserStats {
+
+        Double handleTime;
+        Integer replies;
+        Double happinessScore;
+        Integer customersHelped;
+        Double previousHandleTime;
+        String name;
+        Integer previousCustomersHelped;
+        Double previousHappinessScore;
+        String user;
+        Integer previousReplies;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/user/ConversationStats.java
+++ b/src/main/java/net/helpscout/api/model/report/user/ConversationStats.java
@@ -1,0 +1,30 @@
+package net.helpscout.api.model.report.user;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.cbo.Status;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConversationStats {
+
+    Integer number;
+    Integer responseTime;
+    Integer firstResponseTime;
+    Integer resolveTime;
+    Integer repliesSent;
+    Integer id;
+    Status status;
+    List<Customer> customers;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class Customer {
+
+        Integer id;
+        String name;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/user/UserHappiness.java
+++ b/src/main/java/net/helpscout/api/model/report/user/UserHappiness.java
@@ -1,0 +1,44 @@
+package net.helpscout.api.model.report.user;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserHappiness {
+
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    MultipleTimeRangeStats deltas;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Double great;
+        Double okay;
+        Double notGood;
+        Double greatCount;
+        Integer okayCount;
+        Integer notGoodCount;
+        Integer totalCustomers;
+        Integer totalCustomersWithRatings;
+        Integer ratingsCount;
+        Double ratingsPercent;
+        Double happinessScore;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class MultipleTimeRangeStats {
+
+        Double great;
+        Double okay;
+        Double notGood;
+        Double greatCount;
+        Double okayCount;
+        Double notGoodCount;
+        Double happinessScore;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/user/UserHappiness.java
+++ b/src/main/java/net/helpscout/api/model/report/user/UserHappiness.java
@@ -1,13 +1,17 @@
 package net.helpscout.api.model.report.user;
 
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
+import net.helpscout.api.model.report.common.Tag;
 
 @Data
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class UserHappiness {
 
+    List<Tag> filterTags;
     TimeRangeStats current;
     TimeRangeStats previous;
     MultipleTimeRangeStats deltas;

--- a/src/main/java/net/helpscout/api/model/report/user/UserReport.java
+++ b/src/main/java/net/helpscout/api/model/report/user/UserReport.java
@@ -1,0 +1,90 @@
+package net.helpscout.api.model.report.user;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import net.helpscout.api.model.report.common.Tag;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserReport {
+
+    List<Tag> filterTags;
+    User user;
+    TimeRangeStats current;
+    TimeRangeStats previous;
+    MultipleTimeRangeStats deltas;
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class User {
+
+        Date createdAt;
+        String photoUrl;
+        Boolean hasPhoto;
+        String name;
+        Integer totalCustomersHelped;
+        Integer id;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class TimeRangeStats {
+
+        Date startDate;
+        Date endDate;
+        Integer totalDays;
+        Integer resolved;
+        Integer conversationsCreated;
+        Integer closed;
+        List<Rating> ratings;
+        Integer totalReplies;
+        Integer resolvedOnFirstReply;
+        Double percentResolvedOnFirstReply;
+        Double repliesToResolve;
+        Double handleTime;
+        Double happinessScore;
+        Double responseTime;
+        Double resolutionTime;
+        Double repliesPerDay;
+        Integer customersHelped;
+        Integer totalConversations;
+        Double conversationsPerDay;
+        Integer busiestDay;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class MultipleTimeRangeStats {
+
+        Double totalConversations;
+        Double customersHelped;
+        Double happinessScore;
+        Double repliesPerDay;
+        Double resolvedOnFirstReply;
+        Double handleTime;
+        Double conversationsPerDay;
+        Double resolved;
+        Double repliesToResolve;
+        Double activeConversations;
+        Double totalReplies;
+        Double closed;
+        Double responseTime;
+        Double resolutionTime;
+        Double conversationsCreated;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public class Rating {
+
+        Double repliesSent;
+        Double firstResponseTime;
+        Double resolveTime;
+        String ratingId;
+        Double responseTime;
+    }
+}

--- a/src/main/java/net/helpscout/api/model/report/user/UserReport.java
+++ b/src/main/java/net/helpscout/api/model/report/user/UserReport.java
@@ -40,7 +40,6 @@ public class UserReport {
         Integer resolved;
         Integer conversationsCreated;
         Integer closed;
-        List<Rating> ratings;
         Integer totalReplies;
         Integer resolvedOnFirstReply;
         Double percentResolvedOnFirstReply;
@@ -75,16 +74,5 @@ public class UserReport {
         Double responseTime;
         Double resolutionTime;
         Double conversationsCreated;
-    }
-
-    @Data
-    @FieldDefaults(level = AccessLevel.PRIVATE)
-    public class Rating {
-
-        Double repliesSent;
-        Double firstResponseTime;
-        Double resolveTime;
-        String ratingId;
-        Double responseTime;
     }
 }


### PR DESCRIPTION
# Overview

This adds support for fetching report data via the client library. I tried to be consistent with the existing approach of exposing end points via `ApiClient`, although we probably want to consider creating a 2.0 version of the library at some point that breaks that class down. I also added Lombok to generate POJOs with less boilerplate.

I plan to review the [other issues](https://github.com/helpscout/helpscout-api-java/issues) and [pull requests](https://github.com/helpscout/helpscout-api-java/pulls) with this repository as a separate task.
