### PR TITLE
Teams and custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,36 @@
-### 1.5.1 (October 28,2015)
+### 1.6.0 (February 2, 2016)
+
+* Added Custom Fields and Teams support (Pro Plan features)
+   * there are new methods `getTeam` and `getTeams`
+   * Custom Field responses were added to `Conversation` class
+   * Custom Fields were added to `Mailbox` class
+   * subclasses of `CustomFieldResponse` provide typed access to different custom field types. See [API documentation](http://developer.helpscout.net/help-desk-api/objects/field/)
+* Added more tests for the ApiClient
+
+#### Class model change
+
+API methods that used to return `User` now return `MailboxUser`. `User` and new class `Team` are subtypes of `MailboxUser`.
+
+Affected methods are:
+* `getUser()`
+* `getUsers()`
+* `getUsersForMailbox()`
+* `LineItem.getAssignedTo()`, `LineItem.setAssignedTo()` - `LineItem` is an interface with several subclasses
+
+Affected field:
+* `Conversation.owner`
+
+There is also new dependency - Joda Time
+``` xml
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.9.1</version>
+			<scope>compile</scope>
+		</dependency>
+```
+
+### 1.5.1 (October 28, 2015)
 
 * Address model has been updated to use java.util.Data instead of java.util.Calendar objects, de-serialization from JSON payloads will now work correctly.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Help Scout Java Wrapper
 =======================
 Java Wrapper for the Help Scout API. More information can be found on our [developer site](http://developer.helpscout.net).
 
-Version 1.5.1 Released
+Version 1.6.0 Released
 ---------------------
 Please see the [Changelog](https://github.com/helpscout/helpscout-api-java/blob/master/CHANGELOG.md) for details.
 
@@ -14,6 +14,7 @@ Requirements
 * [Commons IO](http://commons.apache.org/proper/commons-io/)
 * [GSON](https://github.com/google/gson/)
 * [SLF4J](http://www.slf4j.org/)
+* [Joda Time](http://www.joda.org/joda-time/)
 
 Example Usage: API
 ---------------------
@@ -93,6 +94,11 @@ Each method also has a duplicate that allows you to pass in a list of Strings to
 * getUsers()
 * getUsersForMailbox(Long mailboxID)
 * getUser(Long userID)
+
+### Teams
+* getTeams()
+* getTeam()
+* getTeamMembers()
 
 
 Example Usage: Webhooks

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>net.helpscout</groupId>
 	<artifactId>helpscout-api</artifactId>
 	<packaging>jar</packaging>
-	<version>1.5.1</version>
+	<version>1.6.0</version>
 	<name>helpscout-api</name>
 	<url>http://maven.apache.org</url>
 
@@ -42,6 +42,12 @@
 			<version>3.4</version>
 		</dependency>
 		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.9.1</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>
@@ -56,7 +62,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.4</version>
+			<version>1.16.6</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -69,6 +75,12 @@
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock</artifactId>
 			<version>1.57</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/net/helpscout/api/Parser.java
+++ b/src/main/java/net/helpscout/api/Parser.java
@@ -9,6 +9,7 @@ import net.helpscout.api.adapters.*;
 import net.helpscout.api.cbo.*;
 import net.helpscout.api.model.Conversation;
 import net.helpscout.api.model.Customer;
+import net.helpscout.api.model.customfield.CustomFieldResponse;
 import net.helpscout.api.model.ref.PersonRef;
 import net.helpscout.api.model.report.common.DateAndCount;
 import net.helpscout.api.model.thread.LineItem;
@@ -31,6 +32,7 @@ public final class Parser {
         builder.registerTypeAdapter(PersonRef.class, new PersonRefAdapter(builder));
         builder.registerTypeAdapter(LineItem.class, new ThreadsAdapater(builder));
         builder.registerTypeAdapter(DateAndCount.class, new DateAndCountDeserializer(builder));
+        builder.registerTypeAdapter(CustomFieldResponse.class, new CustomFieldResponseAdapter());
     }
 
     public synchronized static Parser getInstance() {

--- a/src/main/java/net/helpscout/api/adapters/CustomFieldResponseAdapter.java
+++ b/src/main/java/net/helpscout/api/adapters/CustomFieldResponseAdapter.java
@@ -1,0 +1,84 @@
+package net.helpscout.api.adapters;
+
+import com.google.gson.*;
+import net.helpscout.api.model.customfield.*;
+
+import java.lang.reflect.Type;
+
+public class CustomFieldResponseAdapter implements JsonSerializer<CustomFieldResponse<?>>, JsonDeserializer<CustomFieldResponse<?>> {
+
+    @Override
+    public JsonElement serialize(CustomFieldResponse customFieldResponse, Type type, JsonSerializationContext jsonSerializationContext) {
+        JsonObject json = new JsonObject();
+        json.addProperty("fieldId", customFieldResponse.getFieldId());
+        json.addProperty("value", customFieldResponse.getStringValue());
+        json.addProperty("name", customFieldResponse.getName());
+        return json;
+    }
+
+    @Override
+    public CustomFieldResponse<?> deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+        JsonElement fieldType = jsonObject.get("type");
+        if (fieldType == null) {
+            throw new JsonParseException("'type' field expected in the JSON");
+        }
+
+        CustomFieldType customFieldType = CustomFieldType.valueOf(fieldType.getAsString());
+        CustomFieldResponse<?> response = createCustomField(customFieldType);
+
+        String value = asString(jsonObject, "value");
+        response.fromStringValue(value);
+
+        Long fieldId = asLong(jsonObject, "fieldId");
+        response.setFieldId(fieldId);
+
+        String fieldName = asString(jsonObject, "name");
+        response.setName(fieldName);
+
+        return response;
+    }
+
+
+    private static CustomFieldResponse<?> createCustomField(CustomFieldType customFieldType) {
+        switch (customFieldType) {
+            case SINGLE_LINE:
+                return new SingleLineCustomFieldResponse();
+            case MULTI_LINE:
+                return new MultiLineCustomFieldResponse();
+            case NUMBER:
+                return new NumberCustomFieldResponse();
+            case DATE:
+                return new DateCustomFieldResponse();
+            case DROPDOWN:
+                return new DropDownCustomFieldResponse();
+            default:
+                throw new JsonParseException("Unknown Custom Field type " + customFieldType);
+        }
+
+    }
+
+    private static String asString(JsonObject jsonObject, String fieldName) {
+        JsonElement value = jsonObject.get(fieldName);
+        if (value != null) {
+            return value.getAsString();
+        } else {
+            return null;
+        }
+    }
+
+    private static Long asLong(JsonObject jsonObject, String fieldName) {
+        JsonElement value = jsonObject.get(fieldName);
+        if (value != null) {
+            return value.getAsLong();
+        } else {
+            return null;
+        }
+    }
+
+}
+
+
+
+

--- a/src/main/java/net/helpscout/api/adapters/PersonRefAdapter.java
+++ b/src/main/java/net/helpscout/api/adapters/PersonRefAdapter.java
@@ -5,7 +5,9 @@ import net.helpscout.api.cbo.JsonThreadLocal;
 import net.helpscout.api.cbo.PersonType;
 import net.helpscout.api.model.ref.CustomerRef;
 import net.helpscout.api.model.ref.PersonRef;
+import net.helpscout.api.model.ref.TeamRef;
 import net.helpscout.api.model.ref.UserRef;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Type;
 
@@ -20,12 +22,26 @@ public class PersonRefAdapter implements JsonDeserializer<PersonRef> {
     public PersonRef deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonElement element = JsonThreadLocal.get();
         String type = element.getAsJsonObject().get("type").getAsString();
-        if (type != null) {
-            PersonType personType = PersonType.findByLabel(type.trim());
-            if (personType == PersonType.Customer) {
-                return gson.create().fromJson(json, CustomerRef.class);
-            }
+        Class<? extends PersonRef> personRefClass = getPersonRefClass(type);
+        return gson.create().fromJson(json, personRefClass);
+    }
+
+
+    private static Class<? extends PersonRef> getPersonRefClass(String personTypeString) {
+        if (StringUtils.isEmpty(personTypeString)) {
+            return UserRef.class;
         }
-        return gson.create().fromJson(json, UserRef.class);
+        PersonType personType = PersonType.findByLabel(personTypeString.trim());
+        switch (personType) {
+            case User:
+                return UserRef.class;
+            case Customer:
+                return CustomerRef.class;
+            case Team:
+                return TeamRef.class;
+            default:
+                return UserRef.class;
+        }
+
     }
 }

--- a/src/main/java/net/helpscout/api/cbo/PersonType.java
+++ b/src/main/java/net/helpscout/api/cbo/PersonType.java
@@ -8,7 +8,8 @@ package net.helpscout.api.cbo;
 public enum PersonType {
 
     User(1, "user"),
-    Customer(2, "customer");
+    Customer(2, "customer"),
+    Team(4,"team");
 
     private final int value;
     private final String label;

--- a/src/main/java/net/helpscout/api/exception/ServerException.java
+++ b/src/main/java/net/helpscout/api/exception/ServerException.java
@@ -10,4 +10,8 @@ public class ServerException extends ApiException {
         super(mesg);    
     }
 
+    public ServerException(String mesg, String details) {
+        super(mesg, details);
+    }
+
 }

--- a/src/main/java/net/helpscout/api/model/Conversation.java
+++ b/src/main/java/net/helpscout/api/model/Conversation.java
@@ -3,16 +3,20 @@ package net.helpscout.api.model;
 import java.util.Date;
 import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import net.helpscout.api.cbo.ConversationType;
 import net.helpscout.api.cbo.Status;
-import net.helpscout.api.model.ref.CustomerRef;
-import net.helpscout.api.model.ref.MailboxRef;
-import net.helpscout.api.model.ref.PersonRef;
-import net.helpscout.api.model.ref.UserRef;
+import net.helpscout.api.model.customfield.CustomFieldResponse;
+import net.helpscout.api.model.ref.*;
 import net.helpscout.api.model.thread.LineItem;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Conversation {
     
     private Long id;
@@ -21,7 +25,7 @@ public class Conversation {
     private boolean isDraft;
     private Long number;
     private Source source;
-    private UserRef owner;
+    private MailboxUserRef owner;
     private MailboxRef mailbox;
     private CustomerRef customer;
     private int threadCount;
@@ -37,6 +41,7 @@ public class Conversation {
     private List<String> bccList;
     private List<String> tags;
     private List<LineItem> threads;
+    private List<? extends CustomFieldResponse> customFields;
 
     public boolean hasCcList() {
         return getCcList() != null && !getCcList().isEmpty();

--- a/src/main/java/net/helpscout/api/model/Mailbox.java
+++ b/src/main/java/net/helpscout/api/model/Mailbox.java
@@ -1,18 +1,20 @@
 package net.helpscout.api.model;
 
 import java.util.Date;
+import java.util.List;
 
 import lombok.Getter;
 import lombok.ToString;
+import net.helpscout.api.model.customfield.CustomField;
 
 @Getter
 @ToString
 public class Mailbox {
-
     private Long id;
     private String name;
     private String slug;
     private String email;
     private Date createdAt;
     private Date modifiedAt;
+    private List<CustomField> customFields;
 }

--- a/src/main/java/net/helpscout/api/model/MailboxUser.java
+++ b/src/main/java/net/helpscout/api/model/MailboxUser.java
@@ -1,0 +1,26 @@
+package net.helpscout.api.model;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Date;
+
+@Getter
+@ToString
+public class MailboxUser {
+
+    public enum UserType {
+        team, user
+    }
+    
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String role;
+    private String timezone;
+    private String photoUrl;
+    private Date createdAt;
+    private Date modifiedAt;
+    private UserType type;
+}

--- a/src/main/java/net/helpscout/api/model/Team.java
+++ b/src/main/java/net/helpscout/api/model/Team.java
@@ -5,6 +5,6 @@ import lombok.ToString;
 
 @Getter
 @ToString(callSuper = true)
-public class User extends MailboxUser {
-
+public class Team extends MailboxUser {
+    
 }

--- a/src/main/java/net/helpscout/api/model/customfield/BaseCustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/BaseCustomFieldResponse.java
@@ -1,0 +1,37 @@
+package net.helpscout.api.model.customfield;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter
+@Getter
+@EqualsAndHashCode
+@ToString(doNotUseGetters = true)
+public abstract class BaseCustomFieldResponse<V> implements CustomFieldResponse<V> {
+
+    protected BaseCustomFieldResponse(CustomFieldType customFieldType) {
+        this.type = customFieldType;
+    }
+
+    private Long fieldId;
+    private String name;
+    private CustomFieldType type;
+    private V value;
+
+    protected abstract String typedToStringValue(V value);
+
+    protected abstract V getTypedValue(String stringValue);
+
+    @Override
+    public String getStringValue() {
+        return typedToStringValue(value);
+    }
+
+    @Override
+    public void fromStringValue(String value) {
+        this.value = getTypedValue(value);
+    }
+
+}

--- a/src/main/java/net/helpscout/api/model/customfield/CustomField.java
+++ b/src/main/java/net/helpscout/api/model/customfield/CustomField.java
@@ -1,0 +1,18 @@
+package net.helpscout.api.model.customfield;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomField {
+    private Long id;
+    private String fieldName;
+    private CustomFieldType fieldType;
+    private boolean required;
+    private Integer order;
+    private List<CustomFieldOption> options;
+}

--- a/src/main/java/net/helpscout/api/model/customfield/CustomFieldOption.java
+++ b/src/main/java/net/helpscout/api/model/customfield/CustomFieldOption.java
@@ -1,0 +1,17 @@
+package net.helpscout.api.model.customfield;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomFieldOption {
+    private Long id;
+    private String label;
+    private Integer order;
+}

--- a/src/main/java/net/helpscout/api/model/customfield/CustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/CustomFieldResponse.java
@@ -1,0 +1,18 @@
+package net.helpscout.api.model.customfield;
+
+public interface CustomFieldResponse<V> {
+
+    Long getFieldId();
+    void setFieldId(Long id);
+
+    String getName();
+    void setName(String name);
+
+    V getValue();
+    void setValue(V value);
+
+    String getStringValue();
+    void fromStringValue(String value);
+
+    CustomFieldType getType();
+}

--- a/src/main/java/net/helpscout/api/model/customfield/CustomFieldType.java
+++ b/src/main/java/net/helpscout/api/model/customfield/CustomFieldType.java
@@ -1,0 +1,9 @@
+package net.helpscout.api.model.customfield;
+
+public enum CustomFieldType {
+    DROPDOWN,
+    SINGLE_LINE,
+    MULTI_LINE,
+    DATE,
+    NUMBER
+}

--- a/src/main/java/net/helpscout/api/model/customfield/DateCustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/DateCustomFieldResponse.java
@@ -1,0 +1,38 @@
+package net.helpscout.api.model.customfield;
+
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.Date;
+
+public class DateCustomFieldResponse extends BaseCustomFieldResponse<Date> {
+
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd";
+    private static final DateTimeFormatter ISO_DATE_FORMAT = DateTimeFormat.forPattern(DATE_TIME_FORMAT).withZoneUTC();
+
+    public DateCustomFieldResponse() {
+        super(CustomFieldType.DATE);
+    }
+
+    public DateCustomFieldResponse(Date date) {
+        this();
+        setValue(date);
+    }
+
+    @Override
+    protected String typedToStringValue(Date value) {
+        return ISO_DATE_FORMAT.print(new LocalDate(value));
+    }
+
+    @Override
+    protected Date getTypedValue(String stringValue) {
+        if(StringUtils.isBlank(stringValue)) {
+            return null;
+        } else {
+            return ISO_DATE_FORMAT.parseLocalDate(stringValue).toDate();
+        }
+    }
+
+}

--- a/src/main/java/net/helpscout/api/model/customfield/DropDownCustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/DropDownCustomFieldResponse.java
@@ -1,0 +1,35 @@
+package net.helpscout.api.model.customfield;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+
+public class DropDownCustomFieldResponse extends BaseCustomFieldResponse<Long> {
+
+    public DropDownCustomFieldResponse() {
+        super(CustomFieldType.DROPDOWN);
+    }
+
+    public DropDownCustomFieldResponse(Long optionId) {
+        this();
+        setValue(optionId);
+    }
+
+    public DropDownCustomFieldResponse(CustomFieldOption customFieldOption) {
+        this();
+        setValue(customFieldOption.getId());
+    }
+
+    @Override
+    protected String typedToStringValue(Long value) {
+        return String.valueOf(value);
+    }
+
+    @Override
+    protected Long getTypedValue(String stringValue) {
+        if(StringUtils.isBlank(stringValue)) {
+            return null;
+        } else {
+            return NumberUtils.createLong(stringValue);
+        }
+    }
+}

--- a/src/main/java/net/helpscout/api/model/customfield/MultiLineCustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/MultiLineCustomFieldResponse.java
@@ -1,0 +1,27 @@
+package net.helpscout.api.model.customfield;
+
+import lombok.ToString;
+
+@ToString(callSuper = true)
+public class MultiLineCustomFieldResponse extends BaseCustomFieldResponse<String> {
+
+    public MultiLineCustomFieldResponse() {
+        super(CustomFieldType.MULTI_LINE);
+    }
+
+    public MultiLineCustomFieldResponse(String value) {
+        this();
+        setValue(value);
+    }
+
+    @Override
+    protected String typedToStringValue(String value) {
+        return value;
+    }
+
+    @Override
+    protected String getTypedValue(String stringValue) {
+        return stringValue;
+    }
+    
+}

--- a/src/main/java/net/helpscout/api/model/customfield/NumberCustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/NumberCustomFieldResponse.java
@@ -1,0 +1,27 @@
+package net.helpscout.api.model.customfield;
+
+import lombok.ToString;
+import org.apache.commons.lang3.math.NumberUtils;
+
+@ToString(callSuper = true)
+public class NumberCustomFieldResponse extends BaseCustomFieldResponse<Number> {
+
+    public NumberCustomFieldResponse() {
+        super(CustomFieldType.NUMBER);
+    }
+
+    public NumberCustomFieldResponse(Number number) {
+        this();
+        setValue(number);
+    }
+
+    @Override
+    protected String typedToStringValue(Number value) {
+        return String.valueOf(value);
+    }
+
+    @Override
+    protected Number getTypedValue(String stringValue) {
+        return NumberUtils.createNumber(stringValue);
+    }
+}

--- a/src/main/java/net/helpscout/api/model/customfield/SingleLineCustomFieldResponse.java
+++ b/src/main/java/net/helpscout/api/model/customfield/SingleLineCustomFieldResponse.java
@@ -1,0 +1,29 @@
+package net.helpscout.api.model.customfield;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class SingleLineCustomFieldResponse extends BaseCustomFieldResponse<String> {
+
+    public SingleLineCustomFieldResponse() {
+        super(CustomFieldType.SINGLE_LINE);
+    }
+
+    public SingleLineCustomFieldResponse(String value) {
+        this();
+        setValue(value);
+    }
+
+    @Override
+    protected String typedToStringValue(String value) {
+        return value;
+    }
+
+    @Override
+    protected String getTypedValue(String stringValue) {
+        return stringValue;
+    }
+
+}

--- a/src/main/java/net/helpscout/api/model/ref/MailboxUserRef.java
+++ b/src/main/java/net/helpscout/api/model/ref/MailboxUserRef.java
@@ -1,0 +1,5 @@
+package net.helpscout.api.model.ref;
+
+public class MailboxUserRef extends AbstractRef {
+    
+}

--- a/src/main/java/net/helpscout/api/model/ref/TeamRef.java
+++ b/src/main/java/net/helpscout/api/model/ref/TeamRef.java
@@ -1,0 +1,5 @@
+package net.helpscout.api.model.ref;
+
+public class TeamRef extends MailboxUserRef {
+    
+}

--- a/src/main/java/net/helpscout/api/model/ref/UserRef.java
+++ b/src/main/java/net/helpscout/api/model/ref/UserRef.java
@@ -1,5 +1,5 @@
 package net.helpscout.api.model.ref;
 
-public class UserRef extends AbstractRef {
+public class UserRef extends MailboxUserRef {
     
 }

--- a/src/main/java/net/helpscout/api/model/thread/BaseLineItem.java
+++ b/src/main/java/net/helpscout/api/model/thread/BaseLineItem.java
@@ -6,13 +6,14 @@ import lombok.Data;
 import net.helpscout.api.cbo.ActionType;
 import net.helpscout.api.cbo.Status;
 import net.helpscout.api.model.ref.MailboxRef;
+import net.helpscout.api.model.ref.MailboxUserRef;
 import net.helpscout.api.model.ref.PersonRef;
 import net.helpscout.api.model.ref.UserRef;
 
 @Data
 public class BaseLineItem implements LineItem {
     
-    private UserRef assignedTo;
+    private MailboxUserRef assignedTo;
     private Status status;
     private PersonRef createdBy;
     private Date createdAt;

--- a/src/main/java/net/helpscout/api/model/thread/ConversationThread.java
+++ b/src/main/java/net/helpscout/api/model/thread/ConversationThread.java
@@ -5,7 +5,9 @@ import net.helpscout.api.cbo.Status;
 import net.helpscout.api.cbo.ThreadState;
 import net.helpscout.api.cbo.ThreadType;
 import net.helpscout.api.model.Attachment;
+import net.helpscout.api.model.MailboxUser;
 import net.helpscout.api.model.ref.MailboxRef;
+import net.helpscout.api.model.ref.MailboxUserRef;
 import net.helpscout.api.model.ref.PersonRef;
 import net.helpscout.api.model.ref.UserRef;
 
@@ -32,7 +34,7 @@ public interface ConversationThread {
     boolean isClosed();
     boolean isSpam();
     boolean isStatusChange();
-    UserRef getAssignedTo();
+    MailboxUserRef getAssignedTo();
     Status getStatus();
     PersonRef getCreatedBy();
     Date getCreatedAt();
@@ -48,7 +50,7 @@ public interface ConversationThread {
     void setCcList(List<String> ccList);
     void setBccList(List<String> bccList);
     void setAttachments(List<Attachment> attachments);
-    void setAssignedTo(UserRef assignedTo);
+    void setAssignedTo(MailboxUserRef assignedTo);
     void setCreatedBy(PersonRef person);
     void setCreatedAt(Date createdAt);
 }

--- a/src/main/java/net/helpscout/api/model/thread/LineItem.java
+++ b/src/main/java/net/helpscout/api/model/thread/LineItem.java
@@ -3,6 +3,7 @@ package net.helpscout.api.model.thread;
 import net.helpscout.api.cbo.ActionType;
 import net.helpscout.api.cbo.Status;
 import net.helpscout.api.model.ref.MailboxRef;
+import net.helpscout.api.model.ref.MailboxUserRef;
 import net.helpscout.api.model.ref.PersonRef;
 import net.helpscout.api.model.ref.UserRef;
 
@@ -16,14 +17,14 @@ public interface LineItem {
     boolean isClosed();
     boolean isSpam();
     boolean isStatusChange();
-    UserRef getAssignedTo();
+    MailboxUserRef getAssignedTo();
     Status getStatus();
     PersonRef getCreatedBy();
     MailboxRef getFromMailbox();
     ActionType getActionType();
     Long getActionSourceId();
 
-    void setAssignedTo(UserRef assignedTo);
+    void setAssignedTo(MailboxUserRef assignedTo);
     void setStatus(Status status);
     void setCreatedBy(PersonRef person);
     void setFromMailbox(MailboxRef mailbox);

--- a/src/test/java/net/helpscout/api/AbstractApiClientTest.java
+++ b/src/test/java/net/helpscout/api/AbstractApiClientTest.java
@@ -1,0 +1,75 @@
+package net.helpscout.api;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import net.helpscout.api.json.JsonFormatter;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.skyscreamer.jsonassert.JSONCompare;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+public class AbstractApiClientTest {
+
+    private static final int PORT = 9091;
+    private static final String BASE_URL = "http://localhost:" + PORT + "/v1/";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(PORT);
+
+    protected static ApiClient client = ApiClient.getInstance();
+
+    @BeforeClass
+    public static void setUpApiClient() {
+        client.setBaseUrl(BASE_URL);
+    }
+
+    @SneakyThrows
+    protected String getResponse(String responseFile) {
+        if (responseFile == null) {
+            return "";
+        }
+        Path responseFilePath = Paths.get(ClassLoader.getSystemResource("responses/" + responseFile + ".json").toURI());
+        return new String(Files.readAllBytes(responseFilePath), "UTF-8");
+    }
+
+    protected void stubGET(String url, String responseName) {
+        givenThat(get(urlEqualTo(url))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse(responseName))));
+    }
+
+
+    @AllArgsConstructor
+    class ApiExceptionMatcher extends TypeSafeMatcher<ApiException> {
+
+        private final String details;
+
+        @SneakyThrows
+        @Override
+        protected boolean matchesSafely(ApiException e) {
+            return (details == null && e.getDetails() == null)
+                    || (details != null && e.getDetails() != null && JSONCompare.compareJSON(details, e.getDetails(), JSONCompareMode.LENIENT).passed());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("exception details ").appendValue(details);
+        }
+
+        @Override
+        protected void describeMismatchSafely(ApiException item, Description mismatchDescription) {
+            mismatchDescription.appendText("were ").appendValue(item.getDetails());
+        }
+    }
+
+}

--- a/src/test/java/net/helpscout/api/ApiClientTest.java
+++ b/src/test/java/net/helpscout/api/ApiClientTest.java
@@ -1,48 +1,24 @@
 package net.helpscout.api;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import lombok.SneakyThrows;
 import lombok.val;
 import net.helpscout.api.exception.InvalidFormatException;
-import net.helpscout.api.json.JsonFormatter;
 import net.helpscout.api.model.Customer;
-
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class ApiClientTest {
-    
-    private static final int PORT = 8080;
-    private static final String BASE_URL = "http://localhost:" + PORT + "/v1/";
-    
+public class ApiClientTest extends AbstractApiClientTest {
+
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(PORT);
+    public ExpectedException thrown = ExpectedException.none();
 
-    private static ApiClient client = ApiClient.getInstance();
-    
-    @BeforeClass
-    public static void setUpApiClient() {
-        client.setBaseUrl(BASE_URL);
-    }
-    
     @Test(expected = InvalidFormatException.class)
     public void shouldThrowInvalidFormatException() throws ApiException {
         givenThat(get(urlEqualTo("/v1/mailboxes.json"))
@@ -52,59 +28,46 @@ public class ApiClientTest {
     }
 
     @Test
+    @SneakyThrows
     public void shouldNotReturnDetailedErrorMessageForBadRequest() {
         givenThat(get(urlEqualTo("/v1/mailboxes.json"))
                 .willReturn(aResponse().withStatus(HTTP_BAD_REQUEST)));
 
-        try {
-            client.getMailboxes();
-        } catch(ApiException e) {
-            assertNull(e.getDetails());
-        }
+        thrown.expect(new ApiExceptionMatcher(null));
+
+        client.getMailboxes();
     }
-    
+
     @Test
+    @SneakyThrows
     public void shouldReturnDetailedErrorMessageForBadRequest() {
         val error = "{\"message\":\"Invalid request.\"}";
-        
+
         givenThat(get(urlEqualTo("/v1/mailboxes.json"))
-            .willReturn(aResponse().withStatus(HTTP_BAD_REQUEST).withBody(error)));
-        
-        try {
-            client.getMailboxes();
-        } catch (ApiException e) {
-            assertThat(e.getDetails(), is(formatted(error)));
-        }
+                .willReturn(aResponse().withStatus(HTTP_BAD_REQUEST)
+                        .withBody(error)));
+
+
+        thrown.expect(new ApiExceptionMatcher(error));
+
+        client.getMailboxes();
     }
-    
-	@Test
-	public void shouldRetrieveSpecificCustomer() throws ApiException {
-		givenThat(get(urlEqualTo("/v1/customers/60984612.json"))
-				.willReturn(aResponse().withStatus(HTTP_OK)
-				.withBody(getResponse("customer"))));
 
-		Long customerId = 60984612L;
-		Customer customer = client.getCustomer(customerId);
-		assertEquals("Peter", customer.getFirstName());
-		assertEquals(customerId, customer.getId());
-		assertNotNull(customer.getAddress().getCreatedAt());
-		Long addressId = 1187643L;
-		assertEquals(addressId, customer.getAddress().getId());
+    @Test
+    public void shouldRetrieveSpecificCustomer() throws ApiException {
+        givenThat(get(urlEqualTo("/v1/customers/60984612.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("customer"))));
 
-	}
+        Long customerId = 60984612L;
+        Customer customer = client.getCustomer(customerId);
 
-	@SneakyThrows
-	private String getResponse(String responseFile) {
-		if (responseFile == null) {
-			return "";
-		}
-		String response = null;
-		Path responseFilePath = Paths.get(ClassLoader.getSystemResource("responses/" + responseFile + ".json").toURI());
-		response = new String(Files.readAllBytes(responseFilePath));
-		return response;
-	}
-    
-    private String formatted(String rawJson) {
-        return new JsonFormatter().format(rawJson);
+        assertEquals("Peter", customer.getFirstName());
+        assertEquals(customerId, customer.getId());
+        assertNotNull(customer.getAddress().getCreatedAt());
+        Long addressId = 1187643L;
+        assertEquals(addressId, customer.getAddress().getId());
     }
+
+
 }

--- a/src/test/java/net/helpscout/api/ConversationApiTest.java
+++ b/src/test/java/net/helpscout/api/ConversationApiTest.java
@@ -1,0 +1,145 @@
+package net.helpscout.api;
+
+import lombok.SneakyThrows;
+import lombok.val;
+import net.helpscout.api.cbo.PersonType;
+import net.helpscout.api.model.Conversation;
+import net.helpscout.api.model.customfield.*;
+import org.hamcrest.Matcher;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.google.common.collect.ImmutableList.of;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNull;
+
+public class ConversationApiTest extends AbstractApiClientTest {
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnCustomFields() {
+        givenThat(get(urlEqualTo("/v1/conversations/10.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("conversation_10"))));
+
+        Conversation conversation = client.getConversation(10L);
+
+        List<SingleLineCustomFieldResponse> responses = of(
+                singleLineCustomField(10L, "Project Name", "Project 1"),
+                singleLineCustomField(11L, "Purchase Order", "")
+        );
+
+        assertThat(conversation.getCustomFields(), (Matcher) equalTo(responses));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldParseConversation_WhenCustomFieldsAreNotPresent() {
+        givenThat(get(urlEqualTo("/v1/conversations/11.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("conversation_11"))));
+
+        Conversation conversation = client.getConversation(11L);
+        assertNull(conversation.getCustomFields());
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldUpdateConversationsWithCustomFields() {
+        givenThat(put(urlEqualTo("/v1/conversations/12.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)));
+
+        Conversation conversation = new Conversation();
+        conversation.setId(12L);
+        conversation.setCustomFields(of(
+                singleLineCustomField(10L, null, "My project")
+        ));
+        client.updateConversation(conversation);
+
+        verify(putRequestedFor(urlEqualTo("/v1/conversations/12.json"))
+                .withRequestBody(equalToJson("{\"id\":12,\"isDraft\":false,\"threadCount\":0,\"customFields\":[{\"fieldId\":10,\"value\":\"My project\"}]}")));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldCreateConversation() {
+        givenThat(post(urlEqualTo("/v1/conversations.json"))
+                .willReturn(aResponse().withStatus(HTTP_CREATED)));
+
+        Conversation conversation = new Conversation();
+        conversation.setCustomFields(of(
+                singleLineCustomField(10L, null, "My project")
+        ));
+        client.createConversation(conversation);
+
+        verify(postRequestedFor(urlEqualTo("/v1/conversations.json"))
+                .withRequestBody(equalToJson("{\"isDraft\":false,\"threadCount\":0,\"customFields\":[{\"fieldId\":10,\"value\":\"My project\"}]}")));
+
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldProperlyParseAllCustomFieldTypes() {
+        givenThat(get(urlEqualTo("/v1/conversations/13.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("conversation_13"))));
+
+        Conversation conversation = client.getConversation(13L);
+        val fields = conversation.getCustomFields();
+
+        assertTypeAndValue(fields.get(0), SingleLineCustomFieldResponse.class, "Project 1");
+        assertTypeAndValue(fields.get(1), MultiLineCustomFieldResponse.class, "Hey");
+        assertTypeAndValue(fields.get(2), NumberCustomFieldResponse.class, 5);
+        assertTypeAndValue(fields.get(3), DateCustomFieldResponse.class, LocalDate.parse("2015-01-02").toDate());
+        assertTypeAndValue(fields.get(4), DropDownCustomFieldResponse.class, 4L);
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldProperlyParseAllCustomFieldProperties() {
+        givenThat(get(urlEqualTo("/v1/conversations/13.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("conversation_13"))));
+
+        Conversation conversation = client.getConversation(13L);
+        val fields = conversation.getCustomFields();
+        val firstField = fields.get(0);
+
+        assertThat(firstField.getFieldId(), equalTo(10L));
+        assertThat(firstField.getName(), equalTo("Project Name"));
+        assertThat(firstField.getValue(), (Matcher) equalTo("Project 1"));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldSetTeamPersonType() {
+        givenThat(get(urlEqualTo("/v1/conversations/10.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("conversation_10"))));
+
+        Conversation conversation = client.getConversation(10L);
+        assertThat(conversation.getOwner().getType(), equalTo(PersonType.Team));
+    }
+
+    private SingleLineCustomFieldResponse singleLineCustomField(Long id, String name, String value) {
+        val field = new SingleLineCustomFieldResponse();
+        field.setName(name);
+        field.setFieldId(id);
+        field.setValue(value);
+        return field;
+    }
+
+    private static void assertTypeAndValue(CustomFieldResponse<?> customFieldResponse, Class<? extends CustomFieldResponse<?>> fieldClass, Object fieldValue) {
+        assertThat(customFieldResponse, instanceOf(fieldClass));
+        val value = customFieldResponse.getValue();
+        assertThat(value, equalTo(fieldValue));
+    }
+
+}

--- a/src/test/java/net/helpscout/api/MailboxApiTest.java
+++ b/src/test/java/net/helpscout/api/MailboxApiTest.java
@@ -1,0 +1,74 @@
+package net.helpscout.api;
+
+import lombok.SneakyThrows;
+import net.helpscout.api.model.customfield.CustomField;
+import net.helpscout.api.model.customfield.CustomFieldOption;
+import net.helpscout.api.model.customfield.CustomFieldType;
+import net.helpscout.api.model.Mailbox;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.google.common.collect.ImmutableList.of;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static net.helpscout.api.model.customfield.CustomFieldType.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class MailboxApiTest extends AbstractApiClientTest {
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnCustomFields_WhenDefined() {
+        givenThat(get(urlEqualTo("/v1/mailboxes/5.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("mailbox_5"))));
+
+        Mailbox mailbox = client.getMailbox(5L);
+
+        List<CustomField> customFields = of(
+                fieldBuilder().fieldName("Favourite Color").id(10L).fieldType(CustomFieldType.DROPDOWN).order(1)
+                        .options(of(
+                                optionBuilder().id(16L).label("Blue").order(2).build(),
+                                optionBuilder().id(15L).label("Red").order(1).build(),
+                                optionBuilder().id(17L).label("White").order(3).build()
+                        )).build(),
+                fieldBuilder().fieldName("Purchase Order").id(11L).fieldType(SINGLE_LINE).order(2)
+                        .options(emptyOptions()).build(),
+                fieldBuilder().fieldName("Customer Notes").id(12L).fieldType(MULTI_LINE).order(3)
+                        .options(emptyOptions()).build(),
+                fieldBuilder().fieldName("Number Requested").id(13L).fieldType(NUMBER).order(4)
+                        .options(emptyOptions()).build(),
+                fieldBuilder().fieldName("Date Of Activity").id(14L).fieldType(DATE).order(5)
+                        .options(emptyOptions()).build());
+
+        assertThat(mailbox.getCustomFields(), equalTo(customFields));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldParseMailbox_WhenCustomFieldsAreNotPresent() {
+        givenThat(get(urlEqualTo("/v1/mailboxes/6.json"))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody(getResponse("mailbox_6"))));
+
+        Mailbox mailbox = client.getMailbox(6L);
+        assertNull(mailbox.getCustomFields());
+    }
+
+    private CustomField.CustomFieldBuilder fieldBuilder() {
+        return CustomField.builder();
+    }
+
+    private CustomFieldOption.CustomFieldOptionBuilder optionBuilder() {
+        return CustomFieldOption.builder();
+    }
+
+    private static List<CustomFieldOption> emptyOptions() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/test/java/net/helpscout/api/TeamsApiTest.java
+++ b/src/test/java/net/helpscout/api/TeamsApiTest.java
@@ -1,0 +1,80 @@
+package net.helpscout.api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class TeamsApiTest extends AbstractApiClientTest {
+
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnPageOfTeams() {
+        stubGET("/v1/teams.json", "teams");
+
+        val teams = client.getTeams();
+
+        assertThat(teams.getItems(), hasSize(1));
+        assertThat(teams.getCount(), is(1));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnPageOfTeams_WhenUsingFieldsParams() {
+        stubGET("/v1/teams.json?fields=id", "teams");
+
+        val teams = client.getTeams(ImmutableList.of("id"));
+
+        assertThat(teams.getItems(), hasSize(1));
+    }
+
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnPageOfTeams_WhenCustomParams() {
+        stubGET("/v1/teams.json?param=value", "teams");
+
+        val teams = client.getTeams(ImmutableMap.of("param","value"));
+
+        assertThat(teams.getItems(), hasSize(1));
+    }
+
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnTeam() {
+        stubGET("/v1/teams/100.json", "team");
+
+        val team = client.getTeam(100L);
+
+        assertThat(team.getId(), equalTo(100L));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnTeam_WhenUsingFieldsParams() {
+        stubGET("/v1/teams/100.json?fields=id", "team");
+
+        val team = client.getTeam(100L, ImmutableList.of("id"));
+
+        assertThat(team.getId(), equalTo(100L));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnTeamMembers() {
+        stubGET("/v1/teams/1/members.json", "users");
+
+        val users = client.getTeamMembers(1L);
+
+        assertThat(users.getItems(), hasSize(1));
+    }
+
+}

--- a/src/test/java/net/helpscout/api/UsersApiTest.java
+++ b/src/test/java/net/helpscout/api/UsersApiTest.java
@@ -1,0 +1,70 @@
+package net.helpscout.api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class UsersApiTest extends AbstractApiClientTest {
+
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnPageOfUsers() {
+        stubGET("/v1/users.json", "users");
+
+        val users = client.getUsers();
+
+        assertThat(users.getItems(), hasSize(1));
+        assertThat(users.getCount(), is(1));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnPageOfUsers_WhenUsingFieldsParams() {
+        stubGET("/v1/users.json?fields=id", "users");
+
+        val users = client.getUsers(ImmutableList.of("id"));
+
+        assertThat(users.getItems(), hasSize(1));
+    }
+
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnPageOfUsers_WhenCustomParams() {
+        stubGET("/v1/users.json?param=value", "users");
+
+        val Users = client.getUsers(ImmutableMap.of("param","value"));
+
+        assertThat(Users.getItems(), hasSize(1));
+    }
+
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnUser() {
+        stubGET("/v1/users/110.json", "user");
+
+        val user = client.getUser(110L);
+
+        assertThat(user.getId(), equalTo(110L));
+    }
+
+    @Test
+    @SneakyThrows
+    public void shouldReturnUser_WhenUsingFieldsParams() {
+        stubGET("/v1/users/110.json?fields=id", "user");
+
+        val user = client.getUser(110L, ImmutableList.of("id"));
+
+        assertThat(user.getId(), equalTo(110L));
+    }
+
+}

--- a/src/test/resources/responses/conversation_10.json
+++ b/src/test/resources/responses/conversation_10.json
@@ -1,0 +1,112 @@
+{
+  "item": {
+    "id": 10,
+    "type": "email",
+    "folderId": 10,
+    "isDraft": false,
+    "number": 123,
+    "owner": {
+      "id": 101,
+      "firstName": "Engineering",
+      "lastName": "",
+      "email": null,
+      "phone": null,
+      "type": "team"
+    },
+    "mailbox": {
+      "id": 1,
+      "name": "Support"
+    },
+    "customer": {
+      "id": 150,
+      "firstName": "Karl",
+      "lastName": "Tester",
+      "email": "karl@worldoftesters.com",
+      "phone": "5552368",
+      "type": "customer",
+      "emails": [
+        "karl@worldoftesters.com",
+        "karl@worldoftesters.net"
+      ]
+    },
+    "threadCount": 1,
+    "status": "active",
+    "subject": "Subject",
+    "preview": "Subject",
+    "createdBy": {
+      "id": 150,
+      "firstName": "Karl",
+      "lastName": "Tester",
+      "email": "karl@worldoftesters.com",
+      "phone": "5552368",
+      "type": "customer",
+      "emails": [
+        "karl@worldoftesters.com",
+        "karl@worldoftesters.net"
+      ]
+    },
+    "createdAt": "2016-01-03T21:35:51Z",
+    "modifiedAt": "2016-01-03T21:35:51Z",
+    "closedAt": null,
+    "closedBy": null,
+    "source": {
+      "type": "email",
+      "via": "customer"
+    },
+    "cc": [],
+    "bcc": [],
+    "tags": null,
+    "threads": [
+      {
+        "id": 3124897,
+        "type": "customer",
+        "assignedTo": null,
+        "status": "active",
+        "createdAt": "2016-01-03T21:35:51Z",
+        "openedAt": null,
+        "createdBy": {
+          "id": 150,
+          "firstName": "Karl",
+          "lastName": "Tester",
+          "email": "karl@worldoftesters.com",
+          "phone": "5552368",
+          "type": "customer",
+          "emails": [
+            "karl@worldoftesters.com",
+            "karl@worldoftesters.net"
+          ]
+        },
+        "source": {
+          "type": "email",
+          "via": "customer"
+        },
+        "actionType": null,
+        "actionSourceId": null,
+        "fromMailbox": null,
+        "state": "published",
+        "customer": null,
+        "body": "<div dir=\"ltr\">Hello</div>",
+        "to": null,
+        "cc": [],
+        "bcc": [],
+        "attachments": null,
+        "savedReplyId": 0,
+        "createdByCustomer": true
+      }
+    ],
+    "customFields": [
+      {
+        "fieldId": 10,
+        "name": "Project Name",
+        "value": "Project 1",
+        "type": "SINGLE_LINE"
+      },
+      {
+        "fieldId": 11,
+        "name": "Purchase Order",
+        "value": "",
+        "type": "SINGLE_LINE"
+      }
+    ]
+  }
+}

--- a/src/test/resources/responses/conversation_11.json
+++ b/src/test/resources/responses/conversation_11.json
@@ -1,0 +1,91 @@
+{
+  "item": {
+    "id": 11,
+    "type": "email",
+    "folderId": 10,
+    "isDraft": false,
+    "number": 123,
+    "owner": null,
+    "mailbox": {
+      "id": 1,
+      "name": "Support"
+    },
+    "customer": {
+      "id": 150,
+      "firstName": "Karl",
+      "lastName": "Tester",
+      "email": "karl@worldoftesters.com",
+      "phone": "5552368",
+      "type": "customer",
+      "emails": [
+        "karl@worldoftesters.com",
+        "karl@worldoftesters.net"
+      ]
+    },
+    "threadCount": 1,
+    "status": "active",
+    "subject": "Subject",
+    "preview": "Subject",
+    "createdBy": {
+      "id": 150,
+      "firstName": "Karl",
+      "lastName": "Tester",
+      "email": "karl@worldoftesters.com",
+      "phone": "5552368",
+      "type": "customer",
+      "emails": [
+        "karl@worldoftesters.com",
+        "karl@worldoftesters.net"
+      ]
+    },
+    "createdAt": "2016-01-03T21:35:51Z",
+    "modifiedAt": "2016-01-03T21:35:51Z",
+    "closedAt": null,
+    "closedBy": null,
+    "source": {
+      "type": "email",
+      "via": "customer"
+    },
+    "cc": [],
+    "bcc": [],
+    "tags": null,
+    "threads": [
+      {
+        "id": 3124897,
+        "type": "customer",
+        "assignedTo": null,
+        "status": "active",
+        "createdAt": "2016-01-03T21:35:51Z",
+        "openedAt": null,
+        "createdBy": {
+          "id": 150,
+          "firstName": "Karl",
+          "lastName": "Tester",
+          "email": "karl@worldoftesters.com",
+          "phone": "5552368",
+          "type": "customer",
+          "emails": [
+            "karl@worldoftesters.com",
+            "karl@worldoftesters.net"
+          ]
+        },
+        "source": {
+          "type": "email",
+          "via": "customer"
+        },
+        "actionType": null,
+        "actionSourceId": null,
+        "fromMailbox": null,
+        "state": "published",
+        "customer": null,
+        "body": "<div dir=\"ltr\">Hello</div>",
+        "to": null,
+        "cc": [],
+        "bcc": [],
+        "attachments": null,
+        "savedReplyId": 0,
+        "createdByCustomer": true
+      }
+    ]
+  }
+}

--- a/src/test/resources/responses/conversation_13.json
+++ b/src/test/resources/responses/conversation_13.json
@@ -1,0 +1,123 @@
+{
+  "item": {
+    "id": 11,
+    "type": "email",
+    "folderId": 10,
+    "isDraft": false,
+    "number": 123,
+    "owner": null,
+    "mailbox": {
+      "id": 1,
+      "name": "Support"
+    },
+    "customer": {
+      "id": 150,
+      "firstName": "Karl",
+      "lastName": "Tester",
+      "email": "karl@worldoftesters.com",
+      "phone": "5552368",
+      "type": "customer",
+      "emails": [
+        "karl@worldoftesters.com",
+        "karl@worldoftesters.net"
+      ]
+    },
+    "threadCount": 1,
+    "status": "active",
+    "subject": "Subject",
+    "preview": "Subject",
+    "createdBy": {
+      "id": 150,
+      "firstName": "Karl",
+      "lastName": "Tester",
+      "email": "karl@worldoftesters.com",
+      "phone": "5552368",
+      "type": "customer",
+      "emails": [
+        "karl@worldoftesters.com",
+        "karl@worldoftesters.net"
+      ]
+    },
+    "createdAt": "2016-01-03T21:35:51Z",
+    "modifiedAt": "2016-01-03T21:35:51Z",
+    "closedAt": null,
+    "closedBy": null,
+    "source": {
+      "type": "email",
+      "via": "customer"
+    },
+    "cc": [],
+    "bcc": [],
+    "tags": null,
+    "threads": [
+      {
+        "id": 3124897,
+        "type": "customer",
+        "assignedTo": null,
+        "status": "active",
+        "createdAt": "2016-01-03T21:35:51Z",
+        "openedAt": null,
+        "createdBy": {
+          "id": 150,
+          "firstName": "Karl",
+          "lastName": "Tester",
+          "email": "karl@worldoftesters.com",
+          "phone": "5552368",
+          "type": "customer",
+          "emails": [
+            "karl@worldoftesters.com",
+            "karl@worldoftesters.net"
+          ]
+        },
+        "source": {
+          "type": "email",
+          "via": "customer"
+        },
+        "actionType": null,
+        "actionSourceId": null,
+        "fromMailbox": null,
+        "state": "published",
+        "customer": null,
+        "body": "<div dir=\"ltr\">Hello</div>",
+        "to": null,
+        "cc": [],
+        "bcc": [],
+        "attachments": null,
+        "savedReplyId": 0,
+        "createdByCustomer": true
+      }
+    ],
+    "customFields": [
+      {
+        "fieldId": 10,
+        "name": "Project Name",
+        "value": "Project 1",
+        "type" : "SINGLE_LINE"
+      },
+      {
+        "fieldId": 11,
+        "name": "Purchase Order",
+        "value": "Hey",
+        "type": "MULTI_LINE"
+      },
+      {
+        "fieldId": 12,
+        "name": "Version",
+        "value": "5",
+        "type": "NUMBER"
+      },
+      {
+        "fieldId": 13,
+        "name": "Original Date",
+        "value": "2015-01-02",
+        "type": "DATE"
+      },
+      {
+        "fieldId": 14,
+        "name": "Favourite color",
+        "value": "4",
+        "type": "DROPDOWN"
+      }
+    ]
+  }
+}

--- a/src/test/resources/responses/mailbox_5.json
+++ b/src/test/resources/responses/mailbox_5.json
@@ -1,0 +1,142 @@
+{
+  "item": {
+    "id": 5,
+    "slug": "a729ed5176e0f202",
+    "name": "Support",
+    "email": "tester@test.com",
+    "folders": [
+      {
+        "id": 1,
+        "name": "Unassigned",
+        "type": "open",
+        "userId": 0,
+        "totalCount": 49,
+        "activeCount": 49,
+        "modifiedAt": "2015-11-24T02:59:19Z"
+      },
+      {
+        "id": 2,
+        "name": "Mine",
+        "type": "mine",
+        "userId": 100,
+        "totalCount": 0,
+        "activeCount": 0,
+        "modifiedAt": "2015-11-11T14:31:51Z"
+      },
+      {
+        "id": 3,
+        "name": "Needs Attention",
+        "type": "needsattention",
+        "userId": 0,
+        "totalCount": 0,
+        "activeCount": 0,
+        "modifiedAt": "2014-08-06T20:32:32Z"
+      },
+      {
+        "id": 4,
+        "name": "Drafts",
+        "type": "drafts",
+        "userId": 0,
+        "totalCount": 1,
+        "activeCount": 1,
+        "modifiedAt": "2015-12-28T20:15:12Z"
+      },
+      {
+        "id": 5,
+        "name": "Assigned",
+        "type": "assigned",
+        "userId": 0,
+        "totalCount": 95,
+        "activeCount": 94,
+        "modifiedAt": "2015-11-04T21:25:20Z"
+      },
+      {
+        "id": 6,
+        "name": "Closed",
+        "type": "closed",
+        "userId": 0,
+        "totalCount": 1624,
+        "activeCount": 0,
+        "modifiedAt": "2015-11-24T02:59:19Z"
+      },
+      {
+        "id": 7,
+        "name": "Spam",
+        "type": "spam",
+        "userId": 0,
+        "totalCount": 0,
+        "activeCount": 0,
+        "modifiedAt": "2014-08-06T20:32:32Z"
+      },
+      {
+        "id": 8,
+        "name": "activity",
+        "type": "smart",
+        "userId": 0,
+        "totalCount": 94,
+        "activeCount": 93,
+        "modifiedAt": "2015-11-24T02:59:19Z"
+      }
+    ],
+    "customFields": [
+      {
+        "id": 10,
+        "fieldName": "Favourite Color",
+        "fieldType": "DROPDOWN",
+        "required": false,
+        "order": 1,
+        "options": [
+          {
+            "id": 16,
+            "label": "Blue",
+            "order": 2
+          },
+          {
+            "id": 15,
+            "label": "Red",
+            "order": 1
+          },
+          {
+            "id": 17,
+            "label": "White",
+            "order": 3
+          }
+        ]
+      },
+      {
+        "id": 11,
+        "fieldName": "Purchase Order",
+        "fieldType": "SINGLE_LINE",
+        "required": false,
+        "order": 2,
+        "options": []
+      },
+      {
+        "id": 12,
+        "fieldName": "Customer Notes",
+        "fieldType": "MULTI_LINE",
+        "required": false,
+        "order": 3,
+        "options": []
+      },
+      {
+        "id": 13,
+        "fieldName": "Number Requested",
+        "fieldType": "NUMBER",
+        "required": false,
+        "order": 4,
+        "options": []
+      },
+      {
+        "id": 14,
+        "fieldName": "Date Of Activity",
+        "fieldType": "DATE",
+        "required": false,
+        "order": 5,
+        "options": []
+      }
+    ],
+    "createdAt": "2014-08-06T20:32:32Z",
+    "modifiedAt": "2015-11-25T21:17:08Z"
+  }
+}

--- a/src/test/resources/responses/mailbox_6.json
+++ b/src/test/resources/responses/mailbox_6.json
@@ -1,0 +1,11 @@
+{
+  "item": {
+    "id": 6,
+    "slug": "a729ed5176e0f202",
+    "name": "Support",
+    "email": "tester@test.com",
+    "folders" : [],
+    "createdAt": "2014-08-06T20:32:32Z",
+    "modifiedAt": "2015-11-25T21:17:08Z"
+  }
+}

--- a/src/test/resources/responses/team.json
+++ b/src/test/resources/responses/team.json
@@ -1,0 +1,15 @@
+{
+  "item": {
+    "id": 100,
+    "firstName": "Some Other",
+    "lastName": "Team",
+    "fullName": "Some Other Team",
+    "email": null,
+    "role": null,
+    "timezone": "America/New_York",
+    "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/users/4.495.png",
+    "createdAt": "2010-09-03T15:55:48Z",
+    "modifiedAt": "2016-01-31T00:04:36Z",
+    "type": "team"
+  }
+}

--- a/src/test/resources/responses/teams.json
+++ b/src/test/resources/responses/teams.json
@@ -1,0 +1,20 @@
+{
+  "page": 1,
+  "pages": 1,
+  "count": 1,
+  "items": [
+    {
+      "id": 104,
+      "firstName": "Some",
+      "lastName": "Team",
+      "fullName": "Some Team",
+      "email": null,
+      "role": null,
+      "timezone": "America/New_York",
+      "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/users/4.495.png",
+      "createdAt": "2010-09-03T15:55:48Z",
+      "modifiedAt": "2016-01-31T00:04:36Z",
+      "type": "team"
+    }
+  ]
+}

--- a/src/test/resources/responses/user.json
+++ b/src/test/resources/responses/user.json
@@ -1,0 +1,15 @@
+{
+  "item": {
+    "id": 110,
+    "firstName": "Robert",
+    "lastName": "Robertson",
+    "fullName": "Robert Robertson",
+    "email": null,
+    "role": null,
+    "timezone": "America/New_York",
+    "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/users/4.495.png",
+    "createdAt": "2010-09-03T15:55:48Z",
+    "modifiedAt": "2016-01-31T00:04:36Z",
+    "type": "user"
+  }
+}

--- a/src/test/resources/responses/users.json
+++ b/src/test/resources/responses/users.json
@@ -1,0 +1,20 @@
+{
+  "page": 1,
+  "pages": 1,
+  "count": 1,
+  "items": [
+    {
+      "id": 110,
+      "firstName": "Robert",
+      "lastName": "Robertson",
+      "fullName": "Robert Robertson",
+      "email": "robert@robertson.com",
+      "role": "user",
+      "timezone": "America/New_York",
+      "photoUrl": "https://d33v4339jhl8k0.cloudfront.net/users/4.495.png",
+      "createdAt": "2010-09-03T15:55:48Z",
+      "modifiedAt": "2016-01-31T00:04:36Z",
+      "type": "user"
+    }
+  ]
+}


### PR DESCRIPTION
### Description
- Added Custom Fields and Teams support (Pro Plan features)
  - there are new methods `getTeam` and `getTeams`
  - Custom Field responses were added to `Conversation` class
  - subclasses of `CustomFieldResponse` provide typed access to different custom field types. See [API documentation](http://developer.helpscout.net/help-desk-api/objects/field/)
- Added more tests for the ApiClient
