### PR TITLE
Fixed cc and bcc fields for Conversation and Thread

### DIFF
--- a/src/main/java/net/helpscout/api/model/Conversation.java
+++ b/src/main/java/net/helpscout/api/model/Conversation.java
@@ -37,18 +37,18 @@ public class Conversation {
     private String closedAt;
     private UserRef closedBy;
     private PersonRef createdBy;
-    private List<String> ccList;
-    private List<String> bccList;
+    private List<String> cc;
+    private List<String> bcc;
     private List<String> tags;
     private List<LineItem> threads;
     private List<? extends CustomFieldResponse> customFields;
 
-    public boolean hasCcList() {
-        return getCcList() != null && !getCcList().isEmpty();
+    public boolean hasCc() {
+        return getCc() != null && !getCc().isEmpty();
     }
 
-    public boolean hasBccList() {
-        return getBccList() != null && !getBccList().isEmpty();
+    public boolean hasBcc() {
+        return getBcc() != null && !getBcc().isEmpty();
     }
 
     public boolean hasThreads() {

--- a/src/main/java/net/helpscout/api/model/thread/AbstractThread.java
+++ b/src/main/java/net/helpscout/api/model/thread/AbstractThread.java
@@ -17,9 +17,9 @@ public class AbstractThread extends BaseLineItem implements ConversationThread {
     private ThreadType type;
     private ThreadState state;
     private String body;
-    private List<String> toList = new ArrayList<String>();
-    private List<String> ccList = new ArrayList<String>();
-    private List<String> bccList = new ArrayList<String>();
+    private List<String> to = new ArrayList<String>();
+    private List<String> cc = new ArrayList<String>();
+    private List<String> bcc = new ArrayList<String>();
     private List<Attachment> attachments = new ArrayList<Attachment>();
     
     public boolean isPublished() {

--- a/src/main/java/net/helpscout/api/model/thread/ConversationThread.java
+++ b/src/main/java/net/helpscout/api/model/thread/ConversationThread.java
@@ -24,9 +24,9 @@ public interface ConversationThread {
     ThreadType getType();
     ThreadState getState();
     String getBody();
-    List<String> getToList();
-    List<String> getCcList();
-    List<String> getBccList();
+    List<String> getTo();
+    List<String> getCc();
+    List<String> getBcc();
     List<Attachment> getAttachments();
     boolean isAssigned();
     boolean isActive();
@@ -46,9 +46,9 @@ public interface ConversationThread {
     void setState(ThreadState state);
     void setStatus(Status status);
     void setBody(String body);
-    void setToList(List<String> toList);
-    void setCcList(List<String> ccList);
-    void setBccList(List<String> bccList);
+    void setTo(List<String> to);
+    void setCc(List<String> cc);
+    void setBcc(List<String> bcc);
     void setAttachments(List<Attachment> attachments);
     void setAssignedTo(MailboxUserRef assignedTo);
     void setCreatedBy(PersonRef person);


### PR DESCRIPTION
In the api documentation, cc and bcc fields are named as cc, bcc not ccList, bccList.
ccList/bccList have null values even when cc/bcc exists. Renaming to cc/bcc works.
http://developer.helpscout.net/help-desk-api/objects/conversation/
http://developer.helpscout.net/help-desk-api/objects/thread/
