### PR TITLE
Fix wrong cc,bcc,to field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.6.1 (February 17, 2016)
+* Fixed [issue](https://github.com/helpscout/helpscout-api-java/pull/19) regarding `cc`, `bcc` and `to` fields in `Conversation` and `AbstractThread` classes
+
 ### 1.6.0 (February 2, 2016)
 
 * Added Custom Fields and Teams support (Pro Plan features)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Help Scout Java Wrapper
 =======================
 Java Wrapper for the Help Scout API. More information can be found on our [developer site](http://developer.helpscout.net).
 
-Version 1.6.0 Released
+Version 1.6.1 Released
 ---------------------
 Please see the [Changelog](https://github.com/helpscout/helpscout-api-java/blob/master/CHANGELOG.md) for details.
 

--- a/src/main/java/net/helpscout/api/model/Conversation.java
+++ b/src/main/java/net/helpscout/api/model/Conversation.java
@@ -3,6 +3,7 @@ package net.helpscout.api.model;
 import java.util.Date;
 import java.util.List;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,7 +38,9 @@ public class Conversation {
     private String closedAt;
     private UserRef closedBy;
     private PersonRef createdBy;
+    @SerializedName("cc")
     private List<String> ccList;
+    @SerializedName("bcc")
     private List<String> bccList;
     private List<String> tags;
     private List<LineItem> threads;

--- a/src/main/java/net/helpscout/api/model/thread/AbstractThread.java
+++ b/src/main/java/net/helpscout/api/model/thread/AbstractThread.java
@@ -3,6 +3,7 @@ package net.helpscout.api.model.thread;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.helpscout.api.cbo.ThreadState;
@@ -17,8 +18,11 @@ public class AbstractThread extends BaseLineItem implements ConversationThread {
     private ThreadType type;
     private ThreadState state;
     private String body;
+    @SerializedName("to")
     private List<String> toList = new ArrayList<String>();
+    @SerializedName("cc")
     private List<String> ccList = new ArrayList<String>();
+    @SerializedName("bcc")
     private List<String> bccList = new ArrayList<String>();
     private List<Attachment> attachments = new ArrayList<Attachment>();
     

--- a/src/test/resources/responses/conversation_11.json
+++ b/src/test/resources/responses/conversation_11.json
@@ -46,8 +46,8 @@
       "type": "email",
       "via": "customer"
     },
-    "cc": [],
-    "bcc": [],
+    "cc": ["test@email1.com", "test@email2.com"],
+    "bcc": ["test1@email1.com"],
     "tags": null,
     "threads": [
       {
@@ -79,9 +79,9 @@
         "state": "published",
         "customer": null,
         "body": "<div dir=\"ltr\">Hello</div>",
-        "to": null,
-        "cc": [],
-        "bcc": [],
+        "to": ["one@two.theee", "one.one@two.three"],
+        "cc": ["some@not.real.com"],
+        "bcc": ["some@other.not.real.com", "another@not.real.com"],
         "attachments": null,
         "savedReplyId": 0,
         "createdByCustomer": true


### PR DESCRIPTION
### Description

@teinemaa found out that `cc`, `bcc` and `to` fields are not serialised and parsed properly. He proposed a fix in #18. 

This PR extends the fix by providing tests and keeping the `Conversation` and `AbstractThread` fields in place and only renaming the JSON fields via GSON `@SerializedName` annotation.
