### PR TITLE
Encode url params to allow using spaces in values (Clean PR)

### DIFF
--- a/src/main/java/net/helpscout/api/ApiClient.java
+++ b/src/main/java/net/helpscout/api/ApiClient.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
@@ -1426,7 +1427,12 @@ public class ApiClient {
                 } else {
                     sb.append("?");
                 }
-                sb.append(key).append("=").append(params.get(key));
+                try {
+                    String encodedParameter = URLEncoder.encode(params.get(key), "UTF-8");
+                    sb.append(key).append("=").append(encodedParameter);
+                } catch(UnsupportedEncodingException ex) {
+                    throw new RuntimeException("Error with encoding of URL parameters");
+                }
             }
             return sb.toString();
         }

--- a/src/main/java/net/helpscout/api/ApiClient.java
+++ b/src/main/java/net/helpscout/api/ApiClient.java
@@ -1,6 +1,7 @@
 package net.helpscout.api;
 
 import com.google.gson.*;
+import lombok.SneakyThrows;
 import net.helpscout.api.adapters.*;
 import net.helpscout.api.cbo.*;
 import net.helpscout.api.exception.*;
@@ -1417,6 +1418,7 @@ public class ApiClient {
         }
     }
 
+    @SneakyThrows
     private String setParams(String url, Map<String, String> params) {
         if (params != null && params.size() > 0) {
             StringBuilder sb = new StringBuilder();
@@ -1427,12 +1429,8 @@ public class ApiClient {
                 } else {
                     sb.append("?");
                 }
-                try {
-                    String encodedParameter = URLEncoder.encode(params.get(key), "UTF-8");
-                    sb.append(key).append("=").append(encodedParameter);
-                } catch(UnsupportedEncodingException ex) {
-                    throw new RuntimeException("Error with encoding of URL parameters");
-                }
+                String encodedParameter = URLEncoder.encode(params.get(key), "UTF-8");
+                sb.append(key).append("=").append(encodedParameter);
             }
             return sb.toString();
         }

--- a/src/test/java/net/helpscout/api/ApiClientTest.java
+++ b/src/test/java/net/helpscout/api/ApiClientTest.java
@@ -8,6 +8,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.net.URLEncoder;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -67,6 +69,16 @@ public class ApiClientTest extends AbstractApiClientTest {
         assertNotNull(customer.getAddress().getCreatedAt());
         Long addressId = 1187643L;
         assertEquals(addressId, customer.getAddress().getId());
+    }
+
+    @Test
+    @SneakyThrows
+    public void checkThatSearchQueryWithSpacesDidNotProduceException() throws ApiException {
+        givenThat(get(urlMatching("/v1/search/conversations.json.*"))
+                .withQueryParam("query", containing(URLEncoder.encode("This is query with spaces", "UTF-8")))
+                .willReturn(aResponse().withStatus(HTTP_OK)
+                        .withBody("{}")));
+        client.searchConversations("This is query with spaces", "", "", 0);
     }
 
 


### PR DESCRIPTION
Fix issue https://github.com/helpscout/helpscout-api-java/issues/23

It was very trick to do something with old branch. I just forgot that I'm working not with regular branch pattern "feature branch->develop", but with two parallel branches without backmerge, so I just create a new one, cause changes were not so big.

> From the brief look, I think it needs a test to expose the issue.  

Actually, I want to start from test, but it is not easy to make unit test, cause `setParams` are private and result of its work goes to another private method `doGet` and then performed call to service. So it is not possible to make clean test without dirty tricks to cover this issue. Do you agree or I missed some way to test simply? It should be refactored.

> And I'd probably extracted URLEncoder.encode(params.get(key), "UTF-8") to a variable to make it more readable.

Agree, sounds reasonable. Make change, but put in local var in `try-catch` scope, because this var is useless outside this block in current code.

> The whole method setParams is ugly :disappointed: and needs refactoring, but that's not your fault.

Agree. As I mentioned above, not only `setParams`, but many other methods are not testable.
